### PR TITLE
chore: update PHP test matrix to [ '8.2', '8.3', '8.4', '8.5', '8.6' ]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.2', '8.3', '8.4', '8.5', '8.6' ]
+        continue-on-error: alse
         
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/update-php.yml
+++ b/.github/workflows/update-php.yml
@@ -102,8 +102,11 @@ jobs:
             else
               echo "Dev version is already up to date"
             fi
-          else
-            echo "No continue-on-error line found, skipping dev version update"
+          elif [ -n "$NEW_DEV" ]; then
+            echo "No continue-on-error line found, inserting after php matrix line $MATRIX_LINE"
+            # Use same indentation as the php: line
+            sed -i "${MATRIX_LINE}a\\${INDENT}continue-on-error: \${{ matrix.php == '${NEW_DEV}' }}" "$TEST_WORKFLOW"
+            CHANGED=true
           fi
 
           echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Automated update of the PHP version matrix in the test workflow.

**New matrix:** `[ '8.2', '8.3', '8.4', '8.5', '8.6' ]`
**Dev/next version (continue-on-error):** `8.6`

Sources: [php.watch API](https://php.watch/api#versions)

This PR was created automatically and will merge itself once all CI checks pass.