### PR TITLE
chore: update PHP test matrix to [ '8.2', '8.3', '8.4', '8.5', '8.6' ]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4', '8.5', '8.6' ]
+        php: [ '8.2', '8.3', '8.4', '8.5', '8.6' ]
 
     continue-on-error: ${{ matrix.php == '8.6' }}
                 


### PR DESCRIPTION
Automated update of the PHP version matrix in the test workflow.

**New matrix:** `[ '8.2', '8.3', '8.4', '8.5', '8.6' ]`
**Dev/next version (continue-on-error):** `8.6`

Sources: [php.watch API](https://php.watch/api#versions)

This PR was created automatically and will merge itself once all CI checks pass.